### PR TITLE
Absolute path can't begin with ./

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ export function installGpg() {
   core.addPath(g10);
   core.endGroup();
 
-  shelljs.exec(`./${path.join(g10, "gpg")} --version`);
+  shelljs.exec(`${path.join(g10, "gpg")} --version`);
 }
 
 run();


### PR DESCRIPTION
It causes errors like this
```
/bin/sh: 1: .//home/runner/work/console-scala-simple/console-scala-simple/gnupg-1.4.23/g10/gpg: not found
```